### PR TITLE
Fix testing under green by not instantiating complex objects during import.

### DIFF
--- a/global_service.py
+++ b/global_service.py
@@ -1,2 +1,0 @@
-from service import PredictService
-predictor = PredictService()

--- a/test.py
+++ b/test.py
@@ -5,7 +5,7 @@ os.environ['TF_CPP_MIN_LOG_LEVEL']='2'
 
 import unittest
 import numpy as np
-from global_service import predictor
+from service import PredictService
 
 
 class Test(unittest.TestCase):
@@ -15,7 +15,7 @@ class Test(unittest.TestCase):
             [0,0.5,0,0,0,0,0,0,2,0,0,0,0]
         ])
         print("Test data: %s" % str(test_data))
-        labels=predictor.predict(test_data)
+        labels = PredictService().predict(test_data)
         expected = [0]
         self.assertListEqual(labels, expected)
 


### PR DESCRIPTION
Green is multiprocess by nature, consisting of a main process that loads all of your code to inspect it for tests, and then worker processes who are assigned to run various tests.  The worker processes independently load their test modules.

It appears that since you were creating a predictor object _on import_, the predictor loaded during the main process's inspection process was interfering with the running of the next predictor loaded in a worker subprocess.

Best practice: Don't run code during import, _especially_ if the code touches anything external to the process (like filesystem or network).

This fix just moves the creation of the predictor into actual test code.  You could alternately devise some way for multiple instantiated objects in different processes to not interfere with each other so that you could still instantiate during import, but that's entirely up to you.